### PR TITLE
Fix plurality typo and make list clearer

### DIFF
--- a/frontpage/src/pages/index.js
+++ b/frontpage/src/pages/index.js
@@ -68,7 +68,7 @@ const IndexPage = () => (
           />
           <Content
             header='General Purpose'
-            body='In the Cloud, Microservices, IoT, Drones, AI and more. Rust compiles to OS binaries, with no VM or GC overhead, and require only a few megabytes of memory.'
+            body='In the Cloud, Microservices, IoT, Drones, AI and more. Rust compiles to OS binaries, has no VM or GC overhead, and requires only a few megabytes of memory.'
           />
           <Content
             header='Modular Framework'


### PR DESCRIPTION
Minor changes, but they make the sentence grammatically correct and easier to read.