### PR TITLE
Image decoding issue

### DIFF
--- a/frontpage/src/components/Organisms/MainVisual/index.js
+++ b/frontpage/src/components/Organisms/MainVisual/index.js
@@ -30,7 +30,7 @@ const MainVisual = () => {
         <MainImage src={Image} />
         <Headline>A Rust framework for building modern, concurrent and resilient applications</Headline>
         <ListBadges>
-          {badges.map(badge => <Badge url={badge.badgeUrl} src={badge.badgeSrc} />)}
+          {badges.map((badge, index) => <Badge key={index} url={badge.badgeUrl} src={badge.badgeSrc} />)}
         </ListBadges>
         <ButtonWrapper>
           <ButtonLink href="/actors/" primary={"1"}>Get Started</ButtonLink>

--- a/frontpage/src/layouts/index.css
+++ b/frontpage/src/layouts/index.css
@@ -88,6 +88,7 @@ sup {
 }
 img {
   border-style: none;
+  transform : translate3d(0,0,0);
 }
 svg:not(:root) {
   overflow: hidden;


### PR DESCRIPTION
To fix the issue that CPU fan make a noise some minutes after web page rendered.
I debugged consoles and find some "Image Decode" running 150~180sec later sometimes.

I guess this issue coming by rasterizing images.
Current site images which include gradient and transparent are rendered by CPU resource as usual images.
But maybe rendering gradients is kind of heavy process.
So I update all <img> to render by GPU resources with this PR.

Let me see with this update whether to be fixed or not.
