### PR TITLE
fix bottom of page links

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/docs/actors.md
+++ b/docs/actors.md
@@ -233,6 +233,6 @@ Riker provides certain guarantees when handling messages:
 
 On this page, you learned the basics of creating a Riker application using actors. Let's move on to the next section to see more comprehensive example using multiple message types:
 
-[Sending multiple message types](messaging)
+[Sending multiple message types](messaging.md)
 
 [1]: https://en.wikipedia.org/wiki/Actor_model

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -84,4 +84,4 @@ Channels form an integral part of the Riker system and provide essential service
 
 Next we'll look at scheduling messages to be sent at a time in the future.
 
-[Scheduling Messages](scheduling)
+[Scheduling Messages](scheduling.md)

--- a/docs/futures.md
+++ b/docs/futures.md
@@ -19,4 +19,4 @@ assert_eq!(block_on(handle), "someval".to_string());
 
 In the next section we'll see how to to test Riker applications.
 
-[Testing](testing)
+[Testing](testing.md)

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -95,4 +95,4 @@ By utilizing `Receive<T>` and `#[actor]`, complex message handling can be define
 
 In the next section, we'll explore the relationship between actors and how actors form a hierarchy.
 
-[Actor Hierarchy](hierarchy)
+[Actor Hierarchy](hierarchy.md)

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -88,8 +88,8 @@ Message scheduling is a core feature of concurrent systems and can drive applica
 
 We've covered the basics of the Riker Framework. Other topics include:
 
-[Configuration](config)
+[Configuration](config.md)
 
-[Running Futures](futures)
+[Running Futures](futures.md)
 
-[Logging](logging)
+[Logging](logging.md)

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -83,4 +83,4 @@ Good supervisor design is key to designing resilient, fault tolerant systems. At
 
 Next we'll see how actor paths can be utilized to message actors without an actor reference and broadcast to entire segments of the actor hierarchy.
 
-[Actor Selection](selection)
+[Actor Selection](selection.md)


### PR DESCRIPTION
in MKDocs style, when linking to an .md, we don't have to supply a
(fully) qualified URL, MKDocs itself can resolve the link properly.

Note that we're still missing the link to

```
[Advanced Messaging](advanced)
```

That page is missing.

Note that this PR also introduces [`.gitattributes`](https://www.git-scm.com/docs/gitattributes), like we did in https://github.com/riker-rs/riker/pull/126 because my editor inadvarteldy introduced LF here, and trying to fix it made it worse.