### PR TITLE
Fixed a dead link at the bottom of the page

### DIFF
--- a/docs/actors.md
+++ b/docs/actors.md
@@ -233,6 +233,6 @@ Riker provides certain guarantees when handling messages:
 
 On this page, you learned the basics of creating a Riker application using actors. Let's move on to the next section to see more comprehensive example using multiple message types:
 
-[Sending multiple message types](messaging)
+[Sending multiple message types](/messaging)
 
 [1]: https://en.wikipedia.org/wiki/Actor_model


### PR DESCRIPTION
The link at the end of the https://riker.rs/actors/ page was a relative link where it should have been an absolute one.