### PR TITLE
fixed broken links

### DIFF
--- a/docs/actors.md
+++ b/docs/actors.md
@@ -233,6 +233,6 @@ Riker provides certain guarantees when handling messages:
 
 On this page, you learned the basics of creating a Riker application using actors. Let's move on to the next section to see more comprehensive example using multiple message types:
 
-[Sending multiple message types](messaging)
-
+[Sending multiple message types](messaging.md)
+q
 [1]: https://en.wikipedia.org/wiki/Actor_model

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -84,4 +84,4 @@ Channels form an integral part of the Riker system and provide essential service
 
 Next we'll look at scheduling messages to be sent at a time in the future.
 
-[Scheduling Messages](scheduling)
+[Scheduling Messages](scheduling.md)

--- a/docs/futures.md
+++ b/docs/futures.md
@@ -19,4 +19,4 @@ assert_eq!(block_on(handle), "someval".to_string());
 
 In the next section we'll see how to to test Riker applications.
 
-[Testing](testing)
+[Testing](testing.md)

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -91,8 +91,8 @@ In this example, we've used `#actor[Add, Sub, Print]` to set up the actor to rec
 !!! note
     When using the `#[actor()]` attribute, the actor's `Msg` associated type should be set to '[DataType]Msg'. E.g. if an actor is a struct named `MyActor`, then the `Actor::Msg` associated type will be `MyActorMsg`.
 
-By utilizing `Receive<T>` and `#[actor]`, complex message handling can be defined clearly and concisely. For more advanced messaging examples see [Advanced Messaging](advanced).
+By utilizing `Receive<T>` and `#[actor]`, complex message handling can be defined clearly and concisely. For more advanced messaging examples see [Advanced Messaging](advanced.md).
 
 In the next section, we'll explore the relationship between actors and how actors form a hierarchy.
 
-[Actor Hierarchy](hierarchy)
+[Actor Hierarchy](hierarchy.md)

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -88,8 +88,8 @@ Message scheduling is a core feature of concurrent systems and can drive applica
 
 We've covered the basics of the Riker Framework. Other topics include:
 
-[Configuration](config)
+[Configuration](config.md)
 
-[Running Futures](futures)
+[Running Futures](futures.md)
 
-[Logging](logging)
+[Logging](logging.md)

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -83,4 +83,4 @@ Good supervisor design is key to designing resilient, fault tolerant systems. At
 
 Next we'll see how actor paths can be utilized to message actors without an actor reference and broadcast to entire segments of the actor hierarchy.
 
-[Actor Selection](selection)
+[Actor Selection](selection.md)


### PR DESCRIPTION
The links pointing the next page on many of the getting started pages were broken (e.g. https://riker.rs/actors/). I updated them in the same style as I saw in the other files. 